### PR TITLE
Add: Support for the LinkAccount card type

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ alexa.response = function() {
 		this.response.response.card = {"type":"Simple","content":content,"title":title,"subtitle":subtitle};
 		return this;
 	};
+	this.linkAccount = function() {
+		this.response.response.card = {"type":"LinkAccount"};
+		return this;
+	};
 	this.shouldEndSession = function(bool,reprompt) {
 		this.response.response.shouldEndSession = bool;
 		if (reprompt) {


### PR DESCRIPTION
I would rather add a `type` option to `#card`, but I don't want to add a fourth parameter. Users will have to be careful to not call `#card` after calling `#linkAccount`.

On the bright side, I guess this protects us if Amazon ever changes the means by which one invokes the account linking process.
